### PR TITLE
Fix permissions of output folder

### DIFF
--- a/docker-scripts/docker-convert.sh
+++ b/docker-scripts/docker-convert.sh
@@ -24,3 +24,7 @@ outputPath="$INPUT_OUTPUTPATH"
 
 convertFolderToHTML "$outputPath"
 
+# set permissions of output folder to the same as the input folder - fixes #1
+if [ -d "$inputPath" ] && [ -d "$outputPath" ]; then
+    chown $(stat "$inputPath" -c %u:%g) "$outputPath" -R
+fi


### PR DESCRIPTION
My proposed solution is to run a `chown` on the `outputPath` at the end of the convert script.
To determine the correct permissions, I opted to get them from the `inputPath` directory rather than hardcoding them which should be more future proof.

Fixes #1